### PR TITLE
Ignore non-security tests

### DIFF
--- a/get_source.sh
+++ b/get_source.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+git clone git://git.openstack.org/openstack/cinder
+git clone git://git.openstack.org/openstack/glance
+git clone git://git.openstack.org/openstack/keystone
+git clone git://git.openstack.org/openstack/neutron
+git clone git://git.openstack.org/openstack/nova
+git clone git://git.openstack.org/openstack/swift

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,33 +27,6 @@ packages =
 
 [entry_points]
 flake8.extension =
-    H000 = hacking.core:ProxyChecks
-    H101 = hacking.checks.comments:hacking_todo_format
-    H102 = hacking.checks.comments:hacking_has_license
-    H103 = hacking.checks.comments:hacking_has_correct_license
-    H104 = hacking.checks.comments:hacking_has_only_comments
-    H201 = hacking.checks.except_checks:hacking_except_format
-    H202 = hacking.checks.except_checks:hacking_except_format_assert
-    H231 = hacking.checks.python23:hacking_python3x_except_compatible
-    H232 = hacking.checks.python23:hacking_python3x_octal_literals
-    H233 = hacking.checks.python23:hacking_python3x_print_function
-    H234 = hacking.checks.python23:hacking_no_assert_equals
-    H235 = hacking.checks.python23:hacking_no_assert_underscore
-    H236 = hacking.checks.python23:hacking_python3x_metaclass
-    H237 = hacking.checks.python23:hacking_no_removed_module
-    H301 = hacking.checks.imports:hacking_import_rules
-    H305 = hacking.checks.imports:hacking_import_groups
-    H306 = hacking.checks.imports:hacking_import_alphabetical
-    H307 = hacking.checks.imports:hacking_import_groups_together
-    H401 = hacking.checks.docstrings:hacking_docstring_start_space
-    H403 = hacking.checks.docstrings:hacking_docstring_multiline_end
-    H404 = hacking.checks.docstrings:hacking_docstring_multiline_start
-    H405 = hacking.checks.docstrings:hacking_docstring_summary
-    H501 = hacking.checks.dictlist:hacking_no_locals
-    H700 = hacking.checks.localization:hacking_localization_strings
-    H801 = hacking.checks.git:OnceGitCheckCommitTitleBug
-    H802 = hacking.checks.git:OnceGitCheckCommitTitleLength
-    H903 = hacking.checks.other:hacking_no_cr
     S006 = hacking.checks.security:hacking_no_pickle
 
 [build_sphinx]

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ commands = python setup.py build_sphinx
 
 [flake8]
 exclude = .venv,.tox,dist,doc,*.egg,build
+ignore = E113,E121,E122,E123,E124,E125,E129,E126,E127,E128,E131,E251,E265,E501,E711,E712,E713,F401,F402,F811,F812,F821,F841
 show-source = true
 
 [hacking]


### PR DESCRIPTION
This elimintes non-security hacking tests and ignores non-security
PEP8 errors.  In addition, a convenience script was added to check
out some of the main OpenStack project source repositories to set
up an environment for scanning.
